### PR TITLE
Basic AlertManager configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,26 @@ for plugin in `jq .plugins[].url repo.json  | tr -d '"'`; do git clone $plugin; 
 cd /var/vcap/bosh/bin/
 ./monit restart grafana
 ```
+
+## Alertmanager
+The `prometheus-boshrelease` does include some predefined alerts for CloudFoundry as well as for BOSH. You can find the alert definitions in [prometheus-boshrelease/src](https://github.com/cloudfoundry-community/prometheus-boshrelease/tree/master/src). Check the `*.alerts` rule files in the corresponding folders. If you create new alerts make sure to add them to the `prometheus.yml` -  the path to the alert rule file as well as a job release for additional new exporters.
+Access the AlertManager to see active alerts or slience them:
+* https://NGINX:9093
+All configured rules as well as their current state can be viewed by accessing Prometheus:
+* https://NGINX:9090/alerts
+Below and example config for `prometheus.yml` to send alerts to slack:
+```
+- name: alertmanager
+    release: prometheus
+    properties:
+      alertmanager:
+        receivers:
+          - name: default-receiver
+            slack_configs:
+            - api_url: https://hooks.slack.com/services/....
+              channel: 'slack-channel'
+              send_resolved: true
+              pretext: "text before the actual alert message"
+        route:
+          receiver: default-receiver
+```

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ cd /var/vcap/bosh/bin/
 The `prometheus-boshrelease` does include some predefined alerts for CloudFoundry as well as for BOSH. You can find the alert definitions in [prometheus-boshrelease/src](https://github.com/cloudfoundry-community/prometheus-boshrelease/tree/master/src). Check the `*.alerts` rule files in the corresponding folders. If you create new alerts make sure to add them to the `prometheus.yml` -  the path to the alert rule file as well as a job release for additional new exporters.
 Access the AlertManager to see active alerts or silence them:
 * https://NGINX:9093
+
 All configured rules as well as their current state can be viewed by accessing Prometheus:
 * https://NGINX:9090/alerts
+
 Below and example config for `prometheus.yml` to send alerts to slack:
 ```
 - name: alertmanager

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ cd /var/vcap/bosh/bin/
 
 ## Alertmanager
 The `prometheus-boshrelease` does include some predefined alerts for CloudFoundry as well as for BOSH. You can find the alert definitions in [prometheus-boshrelease/src](https://github.com/cloudfoundry-community/prometheus-boshrelease/tree/master/src). Check the `*.alerts` rule files in the corresponding folders. If you create new alerts make sure to add them to the `prometheus.yml` -  the path to the alert rule file as well as a job release for additional new exporters.
-Access the AlertManager to see active alerts or slience them:
+Access the AlertManager to see active alerts or silence them:
 * https://NGINX:9093
 All configured rules as well as their current state can be viewed by accessing Prometheus:
 * https://NGINX:9090/alerts

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -111,14 +111,10 @@ instance_groups:
     release: prometheus
     properties:
       alertmanager:
-        route:
-          receiver: default-receiver
         receivers:
           - name: default-receiver
-  - name: bosh_alerts
-    release: prometheus
-  - name: cloudfoundry_alerts
-    release: prometheus
+        route:
+          receiver: default-receiver
   env:
     bosh:
       password: ((alertmanager.vm_password))
@@ -135,6 +131,12 @@ instance_groups:
     release: prometheus
     properties:
       prometheus:
+        rule_files:
+          - /var/vcap/jobs/bosh_alerts/packages/bosh_alerts/bosh_jobs.alerts
+          - /var/vcap/jobs/bosh_alerts/packages/bosh_alerts/bosh_exporter.alerts
+          - /var/vcap/jobs/bosh_alerts/packages/bosh_alerts/bosh_processes.alerts
+          - /var/vcap/jobs/cloudfoundry_alerts/packages/cloudfoundry_alerts/cf_routes.alerts
+          - /var/vcap/jobs/cloudfoundry_alerts/packages/cloudfoundry_alerts/diego.alerts
         scrape_configs:
           - job_name: blackbox
             metrics_path: /probe
@@ -243,6 +245,10 @@ instance_groups:
             static_configs:
               - targets:
                 - localhost:9102
+  - name: bosh_alerts
+    release: prometheus
+  - name: cloudfoundry_alerts
+    release: prometheus
   - name: blackbox_exporter
     release: prometheus
     properties:


### PR DESCRIPTION
These changes enable the basic configuration for the AlertManager. The included alert rules are the ones predefined in the `prometheus-boshrelease` and do cover CloudFoundry as well as BOSH.

The `README.md` includes a sample config for a slack reveicer.